### PR TITLE
use https when requesting from pypi.org

### DIFF
--- a/pypi_search/search.py
+++ b/pypi_search/search.py
@@ -5,7 +5,7 @@ import requests
 
 def find_packages(query: str) -> Optional[List[Dict[str, str]]]:
     query = '+'.join(query.split())
-    response = requests.get(f'http://pypi.org/search/?q={query}')
+    response = requests.get(f'https://pypi.org/search/?q={query}')
     if response.status_code != requests.codes.ok:
         return None
 


### PR DESCRIPTION
Why
===
* It is standard practice to connect to websites using https to help preserve the privacy of the caller and to ensure that the results received are genuine.

What changed
===
* Change search.py to use https when searching pypi